### PR TITLE
Convert-Xml: Expose XslCompiledTransform parameter set

### DIFF
--- a/Xml.psm1
+++ b/Xml.psm1
@@ -217,8 +217,9 @@ function Set-XmlContent {
     process {
         if($Formatted) {
             Set-Content $Path (Format-Xml $Xml)
+        } else {
+            Set-Content $Path $Xml.OuterXml
         }
-        Set-Content $Path $Xml.OuterXml
     }
 }
 
@@ -654,18 +655,19 @@ function Convert-Xml {
         [Alias("StyleSheet")]
         [String]$Xslt,
 
+
         # Specify arguments to the XSL Transformation
         [Alias("Parameters")]
         [hashtable]$Arguments
     )
     begin {
         $StyleSheet = New-Object XslCompiledTransform
-        if(Test-Path $Xslt -EA 0) {
-            Write-Verbose "Loading Stylesheet from $(Resolve-Path $Xslt)"
+            if(Test-Path $Xslt -EA 0) {
+                Write-Verbose "Loading Stylesheet from $(Resolve-Path $Xslt)"
             $StyleSheet.Load( (Resolve-Path $Xslt) )
-        } else {
-            $OFS = "`n"
-            Write-Verbose "$Xslt"
+            } else {
+                $OFS = "`n"
+                Write-Verbose "$Xslt"
             $StyleSheet.Load(([XmlReader]::Create((New-Object System.IO.StringReader $Xslt))))
         }
     }

--- a/Xml.psm1
+++ b/Xml.psm1
@@ -666,11 +666,11 @@ function Convert-Xml {
         if ($PSCmdlet.ParameterSetName -eq "Xsl") {
             if(Test-Path $Xslt -EA 0) {
                 Write-Verbose "Loading Stylesheet from $(Resolve-Path $Xslt)"
-                $CompiledTransform.Load( (Resolve-Path $Xslt), $XsltSettings, $XmlResolver )
+                $CompiledTransform.Load( (Resolve-Path $Xslt) )
             } else {
                 $OFS = "`n"
                 Write-Verbose "$Xslt"
-                $CompiledTransform.Load(([XmlReader]::Create((New-Object System.IO.StringReader $Xslt))), $XsltSettings, $XmlResolver )
+                $CompiledTransform.Load(([XmlReader]::Create((New-Object System.IO.StringReader $Xslt))))
             }
         }
     }


### PR DESCRIPTION
Convert-Xml: Expose XslCompiledTransform parameterset to allow for different XsltSettings and/or XmlResolver. The alternative would be to expose these individual settings, but this makes more sense (to me) in terms of long term maintenance; Also supports re-use of the same XslCompiledTransform for better performance;
Fix Set-XmlContent -Formatted
