### PR TITLE
Fixes #7 Cannot index into a null array

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,4 +111,6 @@ Version History:
 * **6.5** Added -Parameters @{} parameter to New-XDocument to allow local variables to be passed into the module scope. *grumble*
 * **6.6** Expose Convert-Xml and fix a couple of bugs (I can't figure how they got here)
 * **6.7** Add ConvertFrom-Html, add -Formatted switch to Set-XmlContent. Reformat and clean up to (mostly) match the new best practices I'm working on. Finally put the module on github.
+* **6.8** Facilitate reuse of ConvertFrom-XmlDsl. Add Add-XNamespace. Added -BlockType param to New-XDocument (default: XmlDsl), New-XElement (default: Script)
 * **7.0** Update to publish to PowerShell Gallery
+* **7.1** Fix New-XDocument for documents with no namespaces.

--- a/Xml.Tests.ps1
+++ b/Xml.Tests.ps1
@@ -1,0 +1,14 @@
+$scriptroot = Split-Path -Parent (Split-Path -Parent $MyInvocation.MyCommand.Path)
+Import-Module (Join-Path $scriptroot 'XML\XML.psm1') -Force
+
+$PSVersion = $PSVersionTable.PSVersion.Major
+Describe 'New-XDocument' {
+    Context "Strict mode PS$PSVersion" {
+        Set-StrictMode -Version latest
+        It "Creates a simple document with no namespaces" {
+            New-XDocument -root 'movies' -Content {
+                movie { title { 'Aliens' } }
+            }
+        }
+    }
+}

--- a/Xml.psd1
+++ b/Xml.psd1
@@ -4,7 +4,7 @@
 RootModule = 'Xml.psm1'
 
 # Version number of this module.
-ModuleVersion = '7.0'
+ModuleVersion = '7.1'
 
 # ID used to uniquely identify this module
 GUID = '9f58549b-020b-4908-b8ce-8b37ed8f5a2b'
@@ -16,7 +16,7 @@ Author = 'Joel "Jaykul" Bennett'
 CompanyName = 'HuddledMasses.org'
 
 # Copyright statement for this module
-Copyright = '(c) 2016 Joel Bennett. All rights reserved.'
+Copyright = '(c) 2018 Joel Bennett. All rights reserved.'
 
 # Description of the functionality provided by this module
 Description = 'A module providing converters for HTML to XML, various core XML commands and a DSL for generating XML documents.'
@@ -58,7 +58,7 @@ Description = 'A module providing converters for HTML to XML, various core XML c
 # NestedModules = @()
 
 # Functions to export from this module
-FunctionsToExport = 'New-XDocument', 'New-XAttribute', 'New-XElement', 'Remove-XmlNamespace', 'Remove-XmlElement', 'Get-XmlContent', 'Set-XmlContent', 'Convert-Xml', 'Select-Xml', 'Update-Xml', 'Format-Xml', 'ConvertTo-CliXml', 'ConvertFrom-CliXml', 'Import-Html', 'ConvertFrom-Html'
+FunctionsToExport = 'New-XDocument', 'New-XAttribute', 'New-XElement', 'Remove-XmlNamespace', 'Remove-XmlElement', 'Get-XmlContent', 'Set-XmlContent', 'Convert-Xml', 'Select-Xml', 'Update-Xml', 'Format-Xml', 'ConvertTo-CliXml', 'ConvertFrom-CliXml', 'Import-Html', 'ConvertFrom-Html', 'ConvertFrom-XmlDsl'
 
 # Cmdlets to export from this module
 # CmdletsToExport =
@@ -96,7 +96,7 @@ PrivateData = @{
         # IconUri = ''
 
         # ReleaseNotes of this module
-        ReleaseNotes = 'Fix PSScriptAnalyzer rules before uploading to the PowerShellGallery'
+        ReleaseNotes = 'Fix Add-XNamespace for documents requiring no namespace at all.'
 
     } # End of PSData hashtable
 

--- a/Xml.psm1
+++ b/Xml.psm1
@@ -1202,7 +1202,7 @@ Param(
         if( $token.Content.Contains(":") ) {
             $key, $localname = $token.Content -split ":"
             $ScriptText[($token.StartLine - 1)] = $ScriptText[($token.StartLine - 1)].Remove( $token.StartColumn -1, $token.Length ).Insert( $token.StartColumn -1, "'" + $($script:NameSpaceHash[$key] + $localname) + "'" )
-        } else {
+        } elseif ($script:NameSpaceHash -ne $null -and $script:NameSpaceHash.ContainsKey('')) {
             $ScriptText[($token.StartLine - 1)] = $ScriptText[($token.StartLine - 1)].Remove( $token.StartColumn -1, $token.Length ).Insert( $token.StartColumn -1, "'" + $($script:NameSpaceHash[''] + $token.Content) + "'" )
         }
         # insert 'xe' before everything (unless it's a valid command)


### PR DESCRIPTION
Fixes #7 

Avoid New-XDocument runtime error when attempting to a generate a simple document with no namespaces.

I included a simple Pester test which fails without this commit, and succeeds after this commit is applied.